### PR TITLE
Fix omero.web configs, workaround whitenoise prefix bug, ingress hosts is optional

### DIFF
--- a/omero-web/Chart.yaml
+++ b/omero-web/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 5.14.0
 description: OMERO.web
 name: omero-web
-version: 0.4.0
+version: 0.4.1
 icon: https://www.openmicroscopy.org/img/logos/omero-logomark.svg

--- a/omero-web/requirements.yaml
+++ b/omero-web/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: redis
-    version: 17.3.7
+    version: 17.3.11
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled

--- a/omero-web/templates/configmap.yaml
+++ b/omero-web/templates/configmap.yaml
@@ -7,14 +7,7 @@ data:
   # Override https://github.com/ome/omero-web-docker/blob/master/standalone/01-default-webapps.omero
 {{- if .Values.config.defaultWebapps }}
   01-default-webapps.omero: |
-    config append -- omero.web.middleware '{"index": 0, "class": "whitenoise.middleware.WhiteNoiseMiddleware"}'
-
-    config append -- omero.web.apps '"omero_iviewer"'
-    config set -- omero.web.viewer.view omero_iviewer.views.index
-    config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images", "dataset", "well"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
-
-    config append -- omero.web.apps '"omero_parade"'
-    config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
+    {{ .Values.config.defaultWebapps | nindent 4 }}
 {{- end }}
 
   web.omero: |

--- a/omero-web/templates/configmap.yaml
+++ b/omero-web/templates/configmap.yaml
@@ -12,6 +12,10 @@ data:
 
   web.omero: |
     config append -- omero.web.django_additional_settings '["LOGGING", {"version": 1, "disable_existing_loggers": false, "formatters": {"standard": {"format": "%(asctime)s %(levelname)5.5s [%(name)40.40s] (proc.%(process)5.5d) %(funcName)s():%(lineno)d %(message)s"}}, "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "standard"}}, "loggers": {"": {"handlers": ["console"], "level": "DEBUG", "propagate": true}}}]'
+
+    # Workaround bug when prefix set https://github.com/evansd/whitenoise/issues/271
+    config append -- omero.web.django_additional_settings '["WHITENOISE_STATIC_PREFIX", "/static"]'
+
     config set -- omero.web.secure true
     config set -- omero.web.server_list '{{ .Values.serverList | toJson }}'
 

--- a/omero-web/templates/ingress.yaml
+++ b/omero-web/templates/ingress.yaml
@@ -27,9 +27,8 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
-      http:
+  {{- range $host := .Values.ingress.hosts | default (list "") }}
+    - http:
         paths:
           - path: {{ $ingressPath }}
             pathType: Prefix
@@ -38,5 +37,8 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
+    {{- if $host }}
+      host: {{ $host | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/omero-web/values.yaml
+++ b/omero-web/values.yaml
@@ -13,7 +13,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 prefix: /
-serverList: '[["omero-server", 4064, "omero"]]'
+serverList:
+  - ["omero-server", 4064, "omero"]
 config:
   # Set to a multiline string (|) to override the default webapps config
   # https://github.com/ome/omero-web-docker/blob/5.14.0-1/standalone/01-default-webapps.omero

--- a/omero-web/values.yaml
+++ b/omero-web/values.yaml
@@ -38,8 +38,7 @@ ingress:
     {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - chart-example.local
+  hosts: []
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/test-omero-web.yaml
+++ b/test-omero-web.yaml
@@ -1,9 +1,8 @@
 prefix: /
-serverList:
-  # Change the first element to match the OMERO.server service name if needed,
-  # E.g. xxx-omero-server
-  # run `kubectl get svc`
-  - [omero-server, 4064, omero-server]
+# Change the first element to match the OMERO.server service name if needed,
+# run `kubectl get svc`
+# serverList:
+# - [omero-server-svc-hostname, 4064, omero-server]
 config:
   set:
   append:


### PR DESCRIPTION
- Fixes a few bugs in how some config properties were processed
- ingress can be defined with empty hosts to support public ingress controllers which do not require a named host
- Workaround problem with Whitenoise static files when run with a prefix
  - https://github.com/evansd/whitenoise/issues/271