### PR TITLE
omero-server:5.6.10, omero-web:5.24.0

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -7,16 +7,16 @@ on:
 
 jobs:
   precommit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 2
     name: Run pre-commit
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.0
 
   test_omero:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     name: Test OMERO Helm charts
     strategy:
@@ -25,16 +25,25 @@ jobs:
         include:
           - k3s-version: v1.21.0+k3s1
             helm-version: v3.5.4
-          - k3s-version: v1.27.3+k3s1
-            helm-version: v3.12.0
+            # v4 supports k3s 1.24+
+            k3s-helm-version: v3
+          - k3s-version: v1.29.1+k3s1
+            helm-version: v3.14.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # chartpress requires the full history
           fetch-depth: 0
 
-      - id: k3s
-        uses: jupyterhub/action-k3s-helm@v3
+      - uses: jupyterhub/action-k3s-helm@v3
+        if: matrix.k3s-helm-version == 'v3'
+        with:
+          k3s-version: ${{ matrix.k3s-version }}
+          helm-version: ${{ matrix.helm-version }}
+        # This action should export KUBECONFIG
+
+      - uses: jupyterhub/action-k3s-helm@v4
+        if: matrix.k3s-helm-version != 'v3'
         with:
           k3s-version: ${{ matrix.k3s-version }}
           helm-version: ${{ matrix.helm-version }}
@@ -54,7 +63,7 @@ jobs:
 
   # This job can be used as a required status for Pull Requests
   status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 2
     name: Status
     needs:
@@ -67,7 +76,7 @@ jobs:
           echo "test_omero: ${{ needs.test_omero.result }}"
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     name: Publish OMERO Helm charts
@@ -76,12 +85,12 @@ jobs:
       - precommit
       - test_omero
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # chartpress requires the full history
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: pip
@@ -89,12 +98,12 @@ jobs:
 
       - uses: azure/setup-helm@v3
         with:
-          version: v3.5.4
+          version: v3.14.0
 
       - name: Install dependencies
         run: pip install -r dev-requirements.txt
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.1.1
     hooks:
       - id: black
         args: [--target-version=py36]
@@ -9,10 +9,10 @@ repos:
     hooks:
       - id: beautysh
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.22
+    rev: v0.1.23
     hooks:
       - id: helmlint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kubernetes Helm charts for [OMERO](https://www.openmicroscopy.org/).
 
 Add the OMERO Helm chart repository:
 
-    helm repo add omero https://manics.github.io/kubernetes-omero/
+    helm repo add omero https://www.manicstreetpreacher.co.uk/kubernetes-omero/
     helm repo update
 
 Optionally create your OMERO.server and OMERO.web Helm configuration files.

--- a/omero-server/Chart.yaml
+++ b/omero-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 5.6.8
+appVersion: 5.6.10
 description: OMERO.server
 name: omero-server
-version: 0.4.3
+version: 0.4.4
 icon: https://www.openmicroscopy.org/img/logos/omero-logomark.svg

--- a/omero-server/templates/statefulset.yaml
+++ b/omero-server/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           # In openmicroscopy/omero-server these CONFIG envvars have higher

--- a/omero-server/values.yaml
+++ b/omero-server/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: openmicroscopy/omero-server
-  tag: 5.6.8
+  # Default .Chart.AppVersion
+  tag:
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/omero-web/Chart.yaml
+++ b/omero-web/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 5.22.1
+appVersion: 5.24.0
 description: OMERO.web
 name: omero-web
-version: 0.4.3
+version: 0.4.4
 icon: https://www.openmicroscopy.org/img/logos/omero-logomark.svg

--- a/omero-web/templates/deployment.yaml
+++ b/omero-web/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/omero-web/values.yaml
+++ b/omero-web/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: openmicroscopy/omero-web-standalone
-  tag: 5.22.1
+  # Default .Chart.AppVersion
+  tag:
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Updates GitHub action, pre-commit versions, Helm and K3s versions.

Switches to using `.Chart.AppVersion` as the default for `.Values.image.tag` instead of having to duplicate the version.