### PR TITLE
fixes indentation error in omero-server configmap

### DIFF
--- a/omero-server/templates/configmap.yaml
+++ b/omero-server/templates/configmap.yaml
@@ -6,13 +6,13 @@ data:
 
   server.omero: |
     {{- if .Values.certificates.enabled }}
-      certificates
+    certificates
     {{- end }}
 
     {{- if .Values.websockets.enabled }}
-      config set -- omero.client.icetransports ssl,wss{{ if not .Values.websockets.encrypted }},ws{{- end }}
+    config set -- omero.client.icetransports ssl,wss{{ if not .Values.websockets.encrypted }},ws{{- end }}
     {{- else }}
-      config set -- omero.client.icetransports ssl
+    config set -- omero.client.icetransports ssl
     {{- end }}
 
     {{- range $key, $value := .Values.config.set }}


### PR DESCRIPTION
### Issue

Due to the different indentation of the config key/values in the configmap it comes to an error:

```
❯ helm template omero omero-server --set config.set.omero.ldap.config=true
Error: YAML parse error on omero-server/templates/configmap.yaml: error converting YAML to JSON: yaml: line 9: did not find expected key
```